### PR TITLE
Add EmailNonDisposable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RussellLuo/vext
 
-go 1.23.2
+go 1.18
 
 require (
 	github.com/RussellLuo/validating/v3 v3.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,13 @@
 module github.com/RussellLuo/vext
 
-go 1.18
+go 1.23.2
 
 require (
 	github.com/RussellLuo/validating/v3 v3.0.0
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 )
 
-require golang.org/x/exp v0.0.0-20220314205449-43aec2f8a4e7
+require (
+	github.com/th0th/disposableemail v0.0.0-20241105162153-19b67fbf2960
+	golang.org/x/exp v0.0.0-20220314205449-43aec2f8a4e7
+)

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,7 @@ github.com/RussellLuo/validating/v3 v3.0.0 h1:CnUjHJgFMQRO3EVb6OGZmkX+5lYc6m5CTd
 github.com/RussellLuo/validating/v3 v3.0.0/go.mod h1:aXLMAOUVm1Abr2yLXA8g49WVSI6RiiCwn0TXv2iToU0=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/th0th/disposableemail v0.0.0-20241105162153-19b67fbf2960 h1:zAR/3NPUFamNr/9hbzHjYS3AZm5PiLP+LmZgr4Tl2kk=
+github.com/th0th/disposableemail v0.0.0-20241105162153-19b67fbf2960/go.mod h1:De5MaztnK9y7Sx14z6MzyeRHiRtTwAJuIDG/54YVxEM=
 golang.org/x/exp v0.0.0-20220314205449-43aec2f8a4e7 h1:jynE66seADJbyWMUdeOyVTvPtBZt7L6LJHupGwxPZRM=
 golang.org/x/exp v0.0.0-20220314205449-43aec2f8a4e7/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=

--- a/vext.go
+++ b/vext.go
@@ -88,25 +88,11 @@ func EmailNonDisposable() *v.MessageValidator {
 		disposableEmail = disposableEmail2
 	})
 
-	messageValidator := v.MessageValidator{
-		Message: "is disposable e-mail address",
-	}
-
-	messageValidator.Validator = v.Func(func(field *v.Field) v.Errors {
-		value, ok := field.Value.(string)
-		if !ok {
-			return v.NewUnsupportedErrors("EmailNonDisposable", field, "")
-		}
-
+	isValid := func(value string) bool {
 		checkResult := disposableEmail.Check(value)
-		if checkResult.IsDisposable {
-			return v.NewInvalidErrors(field, messageValidator.Message)
-		}
-
-		return nil
-	})
-
-	return &messageValidator
+		return !checkResult.IsDisposable
+	}
+	return v.Is(isValid).Msg("is disposable e-mail address")
 }
 
 // Hash is a leaf validator factory used to create a validator, which will


### PR DESCRIPTION
I added non-disposable e-mail validation function. I am maintaining the `is-email-disposable` package which has the list of disposable e-mail domains myself. It doesn't have the best structure, but at least we can use it from here without getting our hands much dirty :)

I also want to add `PointerValue` function which is here: https://github.com/th0th/validatingextra/blob/main/main.go#L93
But I am not sure if it should go into the `validating` or `vext`. I feel like it should go into `validating` since `vext` has more business-logic, but you make the call 💐 